### PR TITLE
Add progress bar for XML upload

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -22,6 +22,43 @@
 {% block content %}{% endblock %}
 </div>
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+<script>
+document.addEventListener('DOMContentLoaded', function () {
+  const form = document.querySelector('form[action="/upload"]');
+  if (!form) return;
+  const container = form.querySelector('.upload-progress-container');
+  const bar = form.querySelector('.upload-progress');
+  const text = form.querySelector('.progress-text');
+  form.addEventListener('submit', function (e) {
+    const fileInput = form.querySelector('input[type="file"]');
+    if (!fileInput.files.length) return;
+    e.preventDefault();
+    const data = new FormData();
+    data.append('file', fileInput.files[0]);
+    const xhr = new XMLHttpRequest();
+    xhr.open('POST', form.action);
+    let start = Date.now();
+    container.style.display = 'block';
+    xhr.upload.addEventListener('progress', function (ev) {
+      if (ev.lengthComputable) {
+        const pct = (ev.loaded / ev.total) * 100;
+        bar.style.width = pct.toFixed(0) + '%';
+        bar.textContent = pct.toFixed(0) + '%';
+        const elapsed = (Date.now() - start) / 1000;
+        const rate = ev.loaded / elapsed;
+        const remaining = (ev.total - ev.loaded) / rate;
+        if (isFinite(remaining)) {
+          text.textContent = 'Осталось ' + remaining.toFixed(1) + 'с';
+        }
+      }
+    });
+    xhr.onload = function () {
+      location.reload();
+    };
+    xhr.send(data);
+  });
+});
+</script>
 </body>
 </html>
 <!DOCTYPE html>

--- a/templates/index.html
+++ b/templates/index.html
@@ -5,6 +5,10 @@
   <div class="mb-3">
     <input type="file" name="file" class="form-control" required>
   </div>
+  <div class="upload-progress-container progress mb-2" style="display:none;">
+    <div class="upload-progress progress-bar" role="progressbar" style="width:0%">0%</div>
+  </div>
+  <small class="progress-text text-muted"></small>
   <button type="submit" class="btn btn-primary">Upload</button>
 </form>
 
@@ -69,6 +73,10 @@
   <div class="mb-3">
     <input type="file" name="file" class="form-control" required>
   </div>
+  <div class="upload-progress-container progress mb-2" style="display:none;">
+    <div class="upload-progress progress-bar" role="progressbar" style="width:0%">0%</div>
+  </div>
+  <small class="progress-text text-muted"></small>
   <button type="submit" class="btn btn-primary">Upload</button>
 </form>
 
@@ -134,6 +142,10 @@
   <div class="mb-3">
     <input type="file" name="file" class="form-control" required>
   </div>
+  <div class="upload-progress-container progress mb-2" style="display:none;">
+    <div class="upload-progress progress-bar" role="progressbar" style="width:0%">0%</div>
+  </div>
+  <small class="progress-text text-muted"></small>
   <button type="submit" class="btn btn-primary">Upload</button>
 </form>
 


### PR DESCRIPTION
## Summary
- show a progress bar when uploading XML
- estimate remaining time on upload

## Testing
- `python3 -m py_compile app.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6853ca10a8408323938ea0daffb79560