### PR TITLE
Use defusedxml for safer XML parsing

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,7 +1,7 @@
 from flask import Flask, request, jsonify, render_template, redirect, url_for
 from werkzeug.utils import secure_filename
 import sqlite3
-import xml.etree.ElementTree as ET
+import defusedxml.ElementTree as ET
 from collections import defaultdict
 import statistics
 import pandas as pd
@@ -263,7 +263,7 @@ if __name__ == '__main__':
 from flask import Flask, request, jsonify, render_template, redirect, url_for
 from werkzeug.utils import secure_filename
 import sqlite3
-import xml.etree.ElementTree as ET
+import defusedxml.ElementTree as ET
 from collections import defaultdict
 import statistics
 import pandas as pd
@@ -509,7 +509,7 @@ if __name__ == '__main__':
 from flask import Flask, request, jsonify, render_template, redirect, url_for
 from werkzeug.utils import secure_filename
 import sqlite3
-import xml.etree.ElementTree as ET
+import defusedxml.ElementTree as ET
 from collections import defaultdict
 import statistics
 import pandas as pd

--- a/requirements.txt
+++ b/requirements.txt
@@ -37,3 +37,4 @@ typing_extensions==4.14.0
 tzdata==2025.2
 urllib3==2.4.0
 Werkzeug==3.1.3
+defusedxml


### PR DESCRIPTION
## Summary
- replace xml.etree.ElementTree with defusedxml.ElementTree
- list defusedxml dependency

## Testing
- `python -m py_compile app.py remove_duplicate_blocks.py`


------
https://chatgpt.com/codex/tasks/task_e_6853f7ffe0948323858dcf8c38f56bdb