### PR TITLE
Fix analytics 500 error by adding template

### DIFF
--- a/templates/analytics.html
+++ b/templates/analytics.html
@@ -1,0 +1,18 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>Analytics</h2>
+<pre>{{ message }}</pre>
+{% if summaries %}
+  <h3>Predictions</h3>
+  <ul>
+  {% for line in summaries %}
+    <li>{{ line }}</li>
+  {% endfor %}
+  </ul>
+{% endif %}
+<div class="mt-3">
+  <a href="{{ url_for('analytics', accuracy='high') }}" class="btn btn-sm btn-outline-primary">High</a>
+  <a href="{{ url_for('analytics', accuracy='medium') }}" class="btn btn-sm btn-outline-primary">Medium</a>
+  <a href="{{ url_for('analytics', accuracy='low') }}" class="btn btn-sm btn-outline-primary">Low</a>
+</div>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add missing `analytics.html` template so `/analytics` works

## Testing
- `python -m py_compile app.py`
- `curl -s -o /tmp/analytics.html -w "%{http_code}" http://127.0.0.1:5050/analytics` (after running the server)

------
https://chatgpt.com/codex/tasks/task_e_685410f1f61c8323ba046fde909edbb8