### PR TITLE
Improve sleep metrics parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,9 @@ Uploaded data are aggregated per day and stored in a small SQLite database.
 The `/analytics` page now computes correlations between all stored metrics and
 habit entries. Metric names are shown in a human friendly form for all types
 (e.g. `Apple Stand Time`, `Heart Rate`, or `Sleeping Wrist Temperature`).
+Sleep stages from the XML (Awake, In Bed, Asleep Core/Deep/REM) are parsed as
+their durations in minutes so you can analyze how much time was spent in each
+phase per night.
 Use the query parameter `accuracy` (`high`, `medium`, or `low`) or the buttons on the analytics page
 to control how strict the correlation threshold is. Trivial relations like
 `Body Fat Percentage` vs `Body Mass` are hidden unless `show_trivial=1` is passed.


### PR DESCRIPTION
## Summary
- parse Apple Health sleep stages as durations per day
- sum sleep durations when storing metrics
- document sleep stage parsing in README

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile app.py`
- `python app.py` *(server startup verified)*

------
https://chatgpt.com/codex/tasks/task_e_685417e0f2ac8323a6c92f531fbe018c