### PR TITLE
Add day start hour config for parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Uploaded files are stored in the `uploads/` directory, and a simple SQLite datab
 ### Day Start Hour
 
 Set the environment variable `DAY_START_HOUR` (format `HH:MM`) to control when a new day begins. The default is `03:00`.
-If a record starts before this time and continues past it, the measurement is assigned to the next day when aggregating metrics.
+If a record spans past this time, the measurement is assigned to the day that starts at that hour. For example, sleeping from `22:00` on the 4‑th until `07:00` on the 5‑th counts toward the 5‑th.
 
 ## Beginner Guide
 

--- a/app.py
+++ b/app.py
@@ -151,10 +151,13 @@ def parse_xml(path):
                 try:
                     s_dt = datetime.datetime.fromisoformat(start_date)
                     e_dt = datetime.datetime.fromisoformat(end_date) if end_date else None
-                    day_key = s_dt.date().isoformat()
                     cutoff = datetime.datetime.combine(s_dt.date(), DAY_START_TIME)
-                    if e_dt and s_dt.time() < DAY_START_TIME and e_dt > cutoff:
-                        day_key = (s_dt.date() + datetime.timedelta(days=1)).isoformat()
+                    if s_dt.time() >= DAY_START_TIME:
+                        cutoff += datetime.timedelta(days=1)
+                    if e_dt and e_dt > cutoff:
+                        day_key = cutoff.date().isoformat()
+                    else:
+                        day_key = s_dt.date().isoformat()
                 except Exception:
                     day_key = start_date[:10]
 


### PR DESCRIPTION
## Summary
- allow setting a `DAY_START_HOUR` env var
- adjust XML parsing so records that cross this time count toward the next day
- document the configuration in the README

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_68542138c28c8323b2f9e30de74d39bc