### PR TITLE
Add correlation chart and data endpoint

### DIFF
--- a/templates/analytics.html
+++ b/templates/analytics.html
@@ -5,14 +5,66 @@
   <a href="{{ url_for('analytics', accuracy='high') }}" class="btn btn-sm btn-outline-primary">High</a>
   <a href="{{ url_for('analytics', accuracy='medium') }}" class="btn btn-sm btn-outline-primary">Medium</a>
   <a href="{{ url_for('analytics', accuracy='low') }}" class="btn btn-sm btn-outline-primary">Low</a>
+  <select id="period-select" class="form-select form-select-sm w-auto d-inline-block ms-2">
+    <option value="day">Day</option>
+    <option value="week">Week</option>
+    <option value="month">Month</option>
+  </select>
 </div>
-<pre>{{ message }}</pre>
+<p>{{ message }}</p>
+{% if correlations %}
+  <ul id="correlation-list">
+  {% for c1, c2, corr in correlations %}
+    <li><a href="#" class="correlation-link" data-metric1="{{ c1 }}" data-metric2="{{ c2 }}">{{ c1 }} vs {{ c2 }}: {{ '%+.2f'|format(corr) }}</a></li>
+  {% endfor %}
+  </ul>
+{% endif %}
 {% if summaries %}
   <h3>Predictions</h3>
   <ul>
   {% for line in summaries %}
     <li>{{ line }}</li>
   {% endfor %}
-</ul>
+  </ul>
 {% endif %}
+<script>
+const chartEl = document.getElementById('correlationChart');
+let currentM1 = null;
+let currentM2 = null;
+let chart;
+
+function fetchAndShow() {
+  if (!currentM1 || !currentM2) return;
+  const period = document.getElementById('period-select').value;
+  fetch(`/correlation_data?metric1=${encodeURIComponent(currentM1)}&metric2=${encodeURIComponent(currentM2)}&period=${period}`)
+    .then(r => r.json())
+    .then(data => {
+      if (chart) chart.destroy();
+      chartEl.style.display = 'block';
+      chart = new Chart(chartEl, {
+        type: 'line',
+        data: {
+          labels: data.labels,
+          datasets: [
+            {label: currentM1, data: data.metric1, borderColor: 'blue', fill: false},
+            {label: currentM2, data: data.metric2, borderColor: 'orange', fill: false}
+          ]
+        }
+      });
+      const modal = new bootstrap.Modal(document.getElementById('chartModal'));
+      modal.show();
+    });
+}
+
+document.querySelectorAll('.correlation-link').forEach(el => {
+  el.addEventListener('click', e => {
+    e.preventDefault();
+    currentM1 = el.dataset.metric1;
+    currentM2 = el.dataset.metric2;
+    fetchAndShow();
+  });
+});
+
+document.getElementById('period-select').addEventListener('change', fetchAndShow);
+</script>
 {% endblock %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -22,5 +22,15 @@
 {% block content %}{% endblock %}
 </div>
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+<div class="modal fade" id="chartModal" tabindex="-1" aria-hidden="true">
+  <div class="modal-dialog modal-lg">
+    <div class="modal-content">
+      <div class="modal-body">
+        <canvas id="correlationChart" style="display:none" class="w-100"></canvas>
+      </div>
+    </div>
+  </div>
+</div>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add Chart.js and hidden canvas to base template
- allow choosing Day/Week/Month period for analytics
- list correlations as clickable links and show chart in a modal
- provide `/correlation_data` endpoint returning timeseries data

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68542138b3e48323861f9315f67e6209