### PR TITLE
Add period-based lag correlations

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,8 @@ Sleep stages from the XML (Awake, In Bed, Asleep Core/Deep/REM) are parsed as
 their durations in minutes so you can analyze how much time was spent in each
 phase per night.
 Use the query parameter `accuracy` (`high`, `medium`, or `low`) or the buttons on the analytics page
-to control how strict the correlation threshold is. Trivial relations like
+to control how strict the correlation threshold is. The `period` parameter (`day`, `week`, or `month`)
+controls how values are grouped when computing lag correlations. Trivial relations like
 `Body Fat Percentage` vs `Body Mass` are hidden unless `show_trivial=1` is passed.
 
 ## Endpoints

--- a/templates/analytics.html
+++ b/templates/analytics.html
@@ -2,9 +2,14 @@
 {% block content %}
 <h2>Analytics</h2>
 <div class="mb-3">
-  <a href="{{ url_for('analytics', accuracy='high') }}" class="btn btn-sm btn-outline-primary">High</a>
-  <a href="{{ url_for('analytics', accuracy='medium') }}" class="btn btn-sm btn-outline-primary">Medium</a>
-  <a href="{{ url_for('analytics', accuracy='low') }}" class="btn btn-sm btn-outline-primary">Low</a>
+  <a href="{{ url_for('analytics', accuracy='high', period=period) }}" class="btn btn-sm btn-outline-primary">High</a>
+  <a href="{{ url_for('analytics', accuracy='medium', period=period) }}" class="btn btn-sm btn-outline-primary">Medium</a>
+  <a href="{{ url_for('analytics', accuracy='low', period=period) }}" class="btn btn-sm btn-outline-primary">Low</a>
+</div>
+<div class="mb-3">
+  <a href="{{ url_for('analytics', accuracy=accuracy, period='day') }}" class="btn btn-sm btn-outline-secondary">Day</a>
+  <a href="{{ url_for('analytics', accuracy=accuracy, period='week') }}" class="btn btn-sm btn-outline-secondary">Week</a>
+  <a href="{{ url_for('analytics', accuracy=accuracy, period='month') }}" class="btn btn-sm btn-outline-secondary">Month</a>
 </div>
 <pre>{{ message }}</pre>
 {% if summaries %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -53,7 +53,8 @@
 {% endfor %}
 {% endif %}
 
-<p><a href="/analytics">View Analytics</a> (use <code>?accuracy=high|medium|low</code>)</p>
+<p><a href="/analytics">View Analytics</a>
+   (use <code>?accuracy=high|medium|low&period=day|week|month</code>)</p>
 {% if metrics %}
 <h3>Metrics found in last upload:</h3>
 <ul>


### PR DESCRIPTION
## Summary
- handle `period` query param for day/week/month aggregations
- compute lagged correlations between consecutive periods
- include new buttons for period selection
- document `period` parameter and update analytics help text

## Testing
- `python -m py_compile app.py remove_duplicate_blocks.py`

------
https://chatgpt.com/codex/tasks/task_e_68542137d0f483239d595db915d8e8ff