### PR TITLE
Add analytics template

### DIFF
--- a/templates/analytics.html
+++ b/templates/analytics.html
@@ -1,0 +1,21 @@
+{% extends 'base.html' %}
+
+{% block content %}
+<h2 class="mb-4">Analytics</h2>
+
+{% if message %}
+<pre class="p-3 bg-light border rounded">{{ message }}</pre>
+{% endif %}
+
+{% if summaries %}
+<div class="mt-4">
+  <h4>Summaries</h4>
+  <ul class="list-group">
+  {% for s in summaries %}
+    <li class="list-group-item">{{ s }}</li>
+  {% endfor %}
+  </ul>
+</div>
+{% endif %}
+
+{% endblock %}


### PR DESCRIPTION
## Summary
- add a Bootstrap-styled analytics page
- show messages and optional summaries from the `/analytics` route

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_68542c226c5883239ae6c2ba53c98e9b