### PR TITLE
Fix pandas insert error

### DIFF
--- a/app.py
+++ b/app.py
@@ -181,6 +181,11 @@ def analytics():
         'FROM habit_entries JOIN habits ON habit_entries.habit_id = habits.id',
         conn
     )
+    # Explicitly allow duplicate labels in case global pandas options
+    # were set to disallow them. Pivoting with duplicate restrictions
+    # can otherwise raise a ``ValueError`` when inserting index labels.
+    df.flags.allows_duplicate_labels = True
+    habits_df.flags.allows_duplicate_labels = True
     conn.close()
 
     if df.empty:


### PR DESCRIPTION
## Summary
- allow duplicate column labels for pandas DataFrames

## Testing
- `python -m py_compile app.py`
- `python app.py 2>&1 | head -n 5`

------
https://chatgpt.com/codex/tasks/task_e_68542ef0866c8323bc9fe8cdc92e47b8